### PR TITLE
[HWG-10] feat: User, Authorization Entity 분리, Oauth2 로직변경

### DIFF
--- a/src/main/java/com/herewego/herewegoapi/model/entity/Authorization.java
+++ b/src/main/java/com/herewego/herewegoapi/model/entity/Authorization.java
@@ -12,12 +12,12 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "User")
+@Table(name = "Authorization")
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class User {
+public class Authorization {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
@@ -25,24 +25,14 @@ public class User {
     @Column(unique = true, nullable = false)
     private String email;
 
-    @Column(unique = true)
-    private String name;
-
-    private String description;
-
-    private String img;
-
-    @Enumerated(EnumType.STRING)
-    private UserRole role;
-
     @Enumerated(EnumType.STRING)
     private AuthProvider authProvider;
 
-    @Column(name = "team_id")
-    private Integer teamId;
+    @Column(name = "access_token")
+    private String accessToken;
 
-    @Column(name = "game_unit")
-    private String gameUnit;
+    @Column(name = "refresh_token")
+    private String refreshToken;
 
     @org.hibernate.annotations.Generated(GenerationTime.INSERT) @Column(name = "created_date")
     LocalDateTime createdDate;

--- a/src/main/java/com/herewego/herewegoapi/repository/AuthorizationRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/AuthorizationRepository.java
@@ -1,0 +1,28 @@
+package com.herewego.herewegoapi.repository;
+
+import com.herewego.herewegoapi.model.entity.Authorization;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+
+@Repository
+public interface AuthorizationRepository extends JpaRepository<Authorization, Long> {
+
+    @Query("SELECT u.refreshToken FROM Authorization u WHERE u.id=:id")
+    String getRefreshTokenById(@Param("id") Long id);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Authorization u SET u.refreshToken=:token WHERE u.email=:email")
+    void updateRefreshToken(@Param("email") String email, @Param("token") String token);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Authorization u SET u.accessToken=:token WHERE u.email=:email")
+    void updateAccessToken(@Param("email") String email, @Param("token") String token);
+
+}

--- a/src/main/java/com/herewego/herewegoapi/repository/UserRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/UserRepository.java
@@ -15,18 +15,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
-
-    @Query("SELECT u.refreshToken FROM User u WHERE u.id=:id")
-    String getRefreshTokenById(@Param("id") Long id);
-
-    @Transactional
-    @Modifying
-    @Query("UPDATE User u SET u.refreshToken=:token WHERE u.id=:id")
-    void updateRefreshToken(@Param("id") Long id, @Param("token") String token);
-
-    @Transactional
-    @Modifying
-    @Query("UPDATE User u SET u.accessToken=:token WHERE u.id=:id")
-    void updateAccessToken(@Param("id") Long id, @Param("token") String token);
-
 }

--- a/src/main/java/com/herewego/herewegoapi/security/CustomUserDetails.java
+++ b/src/main/java/com/herewego/herewegoapi/security/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.herewego.herewegoapi.security;
 
+import com.herewego.herewegoapi.common.AuthProvider;
 import com.herewego.herewegoapi.model.entity.User;
 import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
@@ -16,12 +17,14 @@ import java.util.Map;
 public class CustomUserDetails implements UserDetails, OAuth2User {
     private Long id;
     private String email;
+    private AuthProvider authprovider;
     private Collection<? extends GrantedAuthority> authorities;
     private Map<String, Object> attributes;
 
-    public CustomUserDetails(Long id, String email, Collection<? extends GrantedAuthority> authorities) {
+    public CustomUserDetails(Long id, String email, AuthProvider authprovider, Collection<? extends GrantedAuthority> authorities) {
         this.id = id;
         this.email = email;
+        this.authprovider = authprovider;
         this.authorities = authorities;
     }
 
@@ -32,6 +35,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
         return new CustomUserDetails(
                 user.getId(),
                 user.getEmail(),
+                user.getAuthProvider(),
                 authorities
         );
     }

--- a/src/main/java/com/herewego/herewegoapi/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/herewego/herewegoapi/security/oauth/CustomOAuth2UserService.java
@@ -5,7 +5,9 @@ import com.herewego.herewegoapi.common.UserRole;
 import com.herewego.herewegoapi.exceptions.ErrorCode;
 import com.herewego.herewegoapi.exceptions.ForwardException;
 import com.herewego.herewegoapi.exceptions.OAuthProcessingException;
+import com.herewego.herewegoapi.model.entity.Authorization;
 import com.herewego.herewegoapi.model.entity.User;
+import com.herewego.herewegoapi.repository.AuthorizationRepository;
 import com.herewego.herewegoapi.repository.UserRepository;
 import com.herewego.herewegoapi.security.CustomUserDetails;
 import com.herewego.herewegoapi.security.oauth.user.OAuth2UserInfo;
@@ -30,6 +32,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    AuthorizationRepository authorizationRepository;
 
     // OAuth2UserRequest에 있는 Access Token으로 유저정보 get
     @Override
@@ -62,9 +67,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             if (authProvider != user.getAuthProvider()) {
                 throw new OAuthProcessingException("Wrong Match Auth Provider");
             }
-
         } else {			// 가입되지 않은 경우
             user = createUser(userInfo, authProvider);
+            createAuthorization(userInfo, authProvider);
         }
         return CustomUserDetails.create(user, oAuth2User.getAttributes());
     }
@@ -78,5 +83,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .authProvider(authProvider)
                 .build();
         return userRepository.save(user);
+    }
+
+    private void createAuthorization(OAuth2UserInfo userInfo, AuthProvider authProvider) {
+        Authorization authorization = Authorization.builder()
+                .email(userInfo.getEmail())
+                .authProvider(authProvider)
+                .build();
     }
 }

--- a/src/main/java/com/herewego/herewegoapi/security/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/herewego/herewegoapi/security/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -40,6 +40,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         LOGGER.debug("인증 완료 : {}");
 
         String targetUrl = determineTargetUrl(request, response, authentication);
+        createJWTToken(response,authentication);
 
         if (response.isCommitted()) {
             LOGGER.debug("Response has already been committed");

--- a/src/main/java/com/herewego/herewegoapi/service/AuthService.java
+++ b/src/main/java/com/herewego/herewegoapi/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.herewego.herewegoapi.service;
 
+import com.herewego.herewegoapi.repository.AuthorizationRepository;
 import com.herewego.herewegoapi.repository.UserRepository;
 import com.herewego.herewegoapi.security.CustomUserDetails;
 import com.herewego.herewegoapi.security.jwt.JwtTokenProvider;
@@ -20,6 +21,9 @@ public class AuthService {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    AuthorizationRepository authorizationRepository;
 
     @Autowired
     JwtTokenProvider tokenProvider;
@@ -43,7 +47,7 @@ public class AuthService {
         Long id = Long.valueOf(user.getName());
 
         // 3. Match Refresh Token
-        String savedToken = userRepository.getRefreshTokenById(id);
+        String savedToken = authorizationRepository.getRefreshTokenById(id);
 
         if (!savedToken.equals(oldRefreshToken)) {
             throw new RuntimeException("Not Matched Refresh Token");


### PR DESCRIPTION
1. Table 간소화를 위해 User와 User Authorization 테이블로 분리
2. Usertable에 game unit 컬럼 추가
3. JWT 토큰 생성시 user의 email로 생성하도록 변경