### PR TITLE
[HWG-13] feat: get User info API 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
 			<artifactId>maven-resources-plugin</artifactId>
 			<version>2.4.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20220924</version>
+		</dependency>
+
 	</dependencies>
 
 

--- a/src/main/java/com/herewego/herewegoapi/common/Utils.java
+++ b/src/main/java/com/herewego/herewegoapi/common/Utils.java
@@ -1,0 +1,18 @@
+package com.herewego.herewegoapi.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Utils {
+    public static List<Integer> gameUnitStringToList(String gameUnitStr){
+        List<Integer> gameUnitList = new ArrayList<>();
+
+        String[] unitArr = gameUnitStr.split(",");
+        for(String unitStr : unitArr) {
+            int unit = Integer.parseInt(unitStr);
+            gameUnitList.add(unit);
+        }
+
+        return gameUnitList;
+    }
+}

--- a/src/main/java/com/herewego/herewegoapi/controller/UserController.java
+++ b/src/main/java/com/herewego/herewegoapi/controller/UserController.java
@@ -4,6 +4,7 @@ import com.herewego.herewegoapi.model.entity.User;
 import com.herewego.herewegoapi.repository.UserRepository;
 import com.herewego.herewegoapi.response.ApiResponse;
 import com.herewego.herewegoapi.security.CustomUserDetails;
+import com.herewego.herewegoapi.service.UserService;
 import com.herewego.herewegoapi.vo.RegisterUserVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -17,6 +18,9 @@ public class UserController {
     @Autowired
     UserRepository userRepository;
 
+    @Autowired
+    UserService userService;
+
     @PostMapping(value = "/users")
     public Object registerUser(
             @RequestHeader(value = "Account-Token") String accountToken,
@@ -28,9 +32,9 @@ public class UserController {
 
     @GetMapping(value = "/users")
     public Object getUserInformation(
-            @RequestHeader(value = "Account-Token") String accountToken,
-            @RequestHeader(value = "Account-Id") String accountId,
-            @RequestBody RegisterUserVO registerUserVO)  {
+            @RequestHeader(value = "Authorization") String accountToken,
+            @RequestHeader(value = "Email") String email,
+            @RequestParam(value = "authorization") String accountTokenParam) {
 
         return ApiResponse.ok();
     }

--- a/src/main/java/com/herewego/herewegoapi/controller/UserController.java
+++ b/src/main/java/com/herewego/herewegoapi/controller/UserController.java
@@ -30,13 +30,14 @@ public class UserController {
         return ApiResponse.ok();
     }
 
+    //Parameter로 들어오는 authorization은 재인증 시에 redirect url에 토큰을 담아서 요청하기 때문에 받아온다.
     @GetMapping(value = "/users")
     public Object getUserInformation(
-            @RequestHeader(value = "Authorization") String accountToken,
-            @RequestHeader(value = "Email") String email,
-            @RequestParam(value = "authorization") String accountTokenParam) {
+            @RequestHeader(required = false, value = "Authorization") String accountToken,
+            @RequestHeader(required = false, value = "Email") String email,
+            @RequestParam(required = false, value = "authorization") String accountTokenParam) {
 
-        return ApiResponse.ok();
+        return userService.getUserInformation(email, accountToken, accountTokenParam);
     }
 
     @PutMapping(value = "/users/gameunit")

--- a/src/main/java/com/herewego/herewegoapi/model/entity/User.java
+++ b/src/main/java/com/herewego/herewegoapi/model/entity/User.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.GenerationTime;
 
 import javax.persistence.*;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@DynamicInsert
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/herewego/herewegoapi/model/response/FavoriteTeamVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/response/FavoriteTeamVO.java
@@ -1,0 +1,22 @@
+package com.herewego.herewegoapi.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FavoriteTeamVO {
+    String teamName;
+
+    String league;
+
+    String icon;
+
+    Integer rank;
+}

--- a/src/main/java/com/herewego/herewegoapi/model/response/LeagueVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/response/LeagueVO.java
@@ -1,0 +1,17 @@
+package com.herewego.herewegoapi.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LeagueVO {
+    String leagueName;
+    String icon;
+}

--- a/src/main/java/com/herewego/herewegoapi/model/response/StatisticsVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/response/StatisticsVO.java
@@ -1,0 +1,198 @@
+package com.herewego.herewegoapi.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.herewego.herewegoapi.model.entity.FixtureStatistics;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StatisticsVO {
+    List<Integer> goal;
+    List<Integer> loss;
+    List<Integer> shotsOnGoal;
+    List<Integer> shotsOffGoal;
+    List<Integer> totalShots;
+    List<Integer> blockedShots;
+    List<Integer> shotsInsideBox;
+    List<Integer> shotsOutsideBox;
+    List<Integer> fouls;
+    List<Integer> cornerKicks;
+    List<Integer> offSide;
+    List<Integer> ballPossession;
+    List<Integer> yellow;
+    List<Integer> red;
+    List<Integer> save;
+    List<Integer> totalPasses;
+    List<Integer> passesAccurate;
+
+    public StatisticsVO(List<FixtureStatistics> fixtureStatistics){
+        List<Integer> goal = new ArrayList<>();
+        List<Integer> loss = new ArrayList<>();
+        List<Integer> shotsOnGoal = new ArrayList<>();
+        List<Integer> shotsOffGoal = new ArrayList<>();
+        List<Integer> totalShots = new ArrayList<>();
+        List<Integer> blockedShots = new ArrayList<>();
+        List<Integer> shotsInsideBox = new ArrayList<>();
+        List<Integer> shotsOutsideBox = new ArrayList<>();
+        List<Integer> fouls = new ArrayList<>();
+        List<Integer> cornerKicks = new ArrayList<>();
+        List<Integer> offSide = new ArrayList<>();
+        List<Integer> ballPossession = new ArrayList<>();
+        List<Integer> yellow = new ArrayList<>();
+        List<Integer> red = new ArrayList<>();
+        List<Integer> save = new ArrayList<>();
+        List<Integer> totalPasses = new ArrayList<>();
+        List<Integer> passesAccurate = new ArrayList<>();
+
+        for (int i = fixtureStatistics.size()-1; i >=0; i--) {
+            String jsonStatistics = fixtureStatistics.get(i).getStatistics();
+            JSONArray statArray = new JSONArray(jsonStatistics);
+
+            goal.add(fixtureStatistics.get(i).getFullScore());
+            loss.add(fixtureStatistics.get(i).getFullLose());
+            for (int j = 0; j < statArray.length(); ++j) {
+                JSONObject stat = statArray.getJSONObject(j);
+                switch ((String)stat.get("type")) {
+                    case "Shots on Goal":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            shotsOnGoal.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            shotsOnGoal.add(0);
+                        break;
+                    case "Shots off Goal":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            shotsOffGoal.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            shotsOffGoal.add(0);
+                        break;
+                    case "Total Shots":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            totalShots.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            totalShots.add(0);
+                        break;
+                    case "Blocked Shots":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            blockedShots.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            blockedShots.add(0);
+                        break;
+                    case "Shots insidebox":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            shotsInsideBox.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            shotsInsideBox.add(0);
+                        break;
+                    case "Shots outsidebox":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            shotsOutsideBox.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            shotsOutsideBox.add(0);
+                        break;
+                    case "Fouls":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            fouls.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            fouls.add(0);
+                        break;
+                    case "Corner Kicks":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            cornerKicks.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            cornerKicks.add(0);
+                        break;
+                    case "Offsides":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            offSide.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            offSide.add(0);
+                        break;
+                    case "Ball Possession":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            String possession = stat.get("value").toString();
+                            ballPossession.add(Integer.parseInt(possession.substring(0, possession.length()-1)));
+                        }
+                        else
+                            ballPossession.add(0);
+                        break;
+                    case "Yellow Cards":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            yellow.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            yellow.add(0);
+                        break;
+                    case "Red Cards":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            red.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            red.add(0);
+                        break;
+                    case "Goalkeeper Saves":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            save.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            save.add(0);
+                        break;
+                    case "Total passes":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            totalPasses.add(Integer.parseInt(stat.get("value").toString()));
+                        }
+                        else
+                            totalPasses.add(0);
+                        break;
+                    case "Passes %":
+                        if (!ObjectUtils.isEmpty(stat.get("value")) && !stat.get("value").toString().equals("null")) {
+                            String accuracy = stat.get("value").toString();
+                            passesAccurate.add(Integer.parseInt(accuracy.substring(0, accuracy.length()-1)));
+                        }
+                        else
+                            passesAccurate.add(0);
+                        break;
+                }
+            }
+        }
+
+        this.goal = goal;
+        this.loss  = loss;
+        this.shotsOnGoal = shotsOnGoal;
+        this.shotsOffGoal = shotsOffGoal;
+        this.totalShots = totalShots;
+        this.blockedShots = blockedShots;
+        this.shotsInsideBox = shotsInsideBox;
+        this.shotsOutsideBox = shotsOutsideBox;
+        this.fouls = fouls;
+        this.cornerKicks = cornerKicks;
+        this.offSide = offSide;
+        this.ballPossession = ballPossession;
+        this.yellow = yellow;
+        this.red = red;
+        this.save = save;
+        this.totalPasses = totalPasses;
+        this.passesAccurate = passesAccurate;
+    }
+}

--- a/src/main/java/com/herewego/herewegoapi/model/response/TeamInfoVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/response/TeamInfoVO.java
@@ -1,0 +1,28 @@
+package com.herewego.herewegoapi.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public class TeamInfoVO {
+    String teamName;
+
+    String league;
+
+    String icon;
+
+    Integer table;
+
+    List<LeagueVO> joining;
+
+    StatisticsVO statistics;
+}

--- a/src/main/java/com/herewego/herewegoapi/model/response/UserVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/response/UserVO.java
@@ -1,0 +1,35 @@
+package com.herewego.herewegoapi.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public class UserVO {
+    String email;
+
+    String accessToken;
+
+    TeamInfoVO homeTeam;
+
+    List<FavoriteTeamVO> favorites;
+
+    List<Integer> gameUnit;
+
+    @Override
+    public String toString() {
+        return "{" +
+                "email='" + email + '\'' +
+                ", accessToken='" + accessToken + '\'' +
+                ", homeTeam=" + homeTeam +
+                ", favorites=" + favorites +
+                ", gameUnit=" + gameUnit +
+                '}';
+    }
+}

--- a/src/main/java/com/herewego/herewegoapi/repository/AuthorizationRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/AuthorizationRepository.java
@@ -30,6 +30,8 @@ public interface AuthorizationRepository extends JpaRepository<Authorization, Lo
 
     Authorization findByEmailAndAuthProvider(String email, AuthProvider authProvider);
 
+    Authorization findByAccessToken(String accessToken);
+
     @Transactional
     void deleteByEmailAndAuthProvider(String email, AuthProvider authProvider);
 

--- a/src/main/java/com/herewego/herewegoapi/repository/FIxtureStatRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/FIxtureStatRepository.java
@@ -1,9 +1,0 @@
-package com.herewego.herewegoapi.repository;
-
-import com.herewego.herewegoapi.model.entity.FixtureStatistics;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface FIxtureStatRepository extends JpaRepository<FixtureStatistics, Long> {
-}

--- a/src/main/java/com/herewego/herewegoapi/repository/FixtureStatRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/FixtureStatRepository.java
@@ -1,0 +1,19 @@
+package com.herewego.herewegoapi.repository;
+
+import com.herewego.herewegoapi.model.entity.FixtureStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Repository
+public interface FixtureStatRepository extends JpaRepository<FixtureStatistics, Long> {
+
+    @Query(value = "SELECT * FROM FixtureStatistics " +
+            "WHERE team_id=:teamId ORDER BY timestamp DESC LIMIT :limit", nativeQuery = true)
+    List<FixtureStatistics> getFixtureStatisticsList(@Param("teamId") Integer teamId, @Param("limit") Integer limit);
+}

--- a/src/main/java/com/herewego/herewegoapi/service/UserService.java
+++ b/src/main/java/com/herewego/herewegoapi/service/UserService.java
@@ -1,13 +1,134 @@
 package com.herewego.herewegoapi.service;
 
-import com.herewego.herewegoapi.repository.UserRepository;
+import com.herewego.herewegoapi.common.Utils;
+import com.herewego.herewegoapi.model.entity.*;
+import com.herewego.herewegoapi.model.response.*;
+import com.herewego.herewegoapi.repository.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.Util;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class UserService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserService.class);
+
+
     @Autowired
     UserRepository userRepository;
 
+    @Autowired
+    AuthorizationRepository authorizationRepository;
 
+    @Autowired
+    TeamRepository teamRepository;
+
+    @Autowired
+    LeagueRepository leagueRepository;
+
+    @Autowired
+    FixtureStatRepository fixtureStatRepository;
+
+    public UserVO getUserInformation(String email, String accountToken, String accountTokenParam) {
+        if (ObjectUtils.isEmpty(accountToken)) {
+            accountToken = accountTokenParam;
+        }
+        if (ObjectUtils.isEmpty(email)) {
+            Optional<Authorization> authorizationOptional = Optional.ofNullable(authorizationRepository.findByAccessToken(accountToken));
+            Authorization authorization = authorizationOptional.orElseGet(()->Authorization.builder().build());
+            email = authorization.getEmail();
+        }
+
+        Optional<User> userOptional = userRepository.findByEmail(email);
+
+        User user = userOptional.orElseGet(()->User.builder().build());
+        LOGGER.debug("User Email : {} ", user.getEmail());
+
+        //등록된 home team 유무에 따른 분기
+        if (!ObjectUtils.isEmpty(user.getTeamId())) {
+            return UserVO.builder()
+                    .email(email)
+                    .accessToken(accountToken)
+                    .favorites(createFavoriteList())
+                    .homeTeam(createTeamInfo(user.getTeamId(), Utils.gameUnitStringToList(user.getGameUnit())))
+                    .gameUnit(Utils.gameUnitStringToList(user.getGameUnit()))
+                    .build();
+        }
+        else {
+            return UserVO.builder()
+                    .email(email)
+                    .accessToken(accountToken)
+                    .favorites(createFavoriteList())
+                    .gameUnit(Utils.gameUnitStringToList(user.getGameUnit()))
+                    .build();
+        }
+    }
+
+
+    //TODO : favorite team list create
+    //현재는 임의로 특정 팀 대입중
+    private List<FavoriteTeamVO> createFavoriteList() {
+        List<FavoriteTeamVO> favoriteTeamVOList = new ArrayList<>();
+
+        Optional<Team> optionalTeam = Optional.ofNullable(teamRepository.findByTeamId(40));
+        optionalTeam.ifPresent(team -> {
+            favoriteTeamVOList.add(FavoriteTeamVO.builder()
+                            .teamName(team.getTeamName())
+                            .league("English Preamier League")
+                            .icon(team.getLogo())
+                            .rank(1)
+                            .build());
+        });
+
+        return favoriteTeamVOList;
+    }
+
+
+    //TODO Team 과 league간의 관계를 맺은 후 vo 재성성, 현재는 임의의 리그를 joining league로 규정 짓고 대입중
+    private TeamInfoVO createTeamInfo(int homeTeamId, List<Integer> gameUnit) {
+        TeamInfoVO teamInfoVO = new TeamInfoVO();
+
+        Optional<Team> optionalTeam = Optional.ofNullable(teamRepository.findByTeamId(homeTeamId));
+        optionalTeam.ifPresent(team -> {
+            teamInfoVO.setTeamName(team.getTeamName());
+            teamInfoVO.setIcon(team.getLogo());
+        });
+
+        //임의 값 넣는 부분
+        Optional<League> optionalLeague = Optional.ofNullable(leagueRepository.findByLeagueId(39));
+        optionalLeague.ifPresent(league -> {
+            teamInfoVO.setLeague(league.getLeagueName());
+            List<LeagueVO> joining = new ArrayList<>();
+            joining.add( LeagueVO.builder()
+                    .leagueName(league.getLeagueName())
+                    .icon(league.getLogo())
+                    .build());
+
+            teamInfoVO.setJoining(joining);
+        });
+        teamInfoVO.setTable(1);
+
+
+        //statistics create
+        teamInfoVO.setStatistics(createStatistics(homeTeamId, gameUnit));
+
+        return teamInfoVO;
+    }
+
+    private StatisticsVO createStatistics(int teamId, List<Integer> gameUnit) {
+        Optional<List<FixtureStatistics>> optionalFixtureStatistics =
+                Optional.ofNullable(fixtureStatRepository.getFixtureStatisticsList(teamId, gameUnit.get(gameUnit.size()-1)));
+
+        if (optionalFixtureStatistics.isPresent()) {
+            return new StatisticsVO(optionalFixtureStatistics.get());
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/com/herewego/herewegoapi/service/UserService.java
+++ b/src/main/java/com/herewego/herewegoapi/service/UserService.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Service;
 public class UserService {
     @Autowired
     UserRepository userRepository;
+
+
 }

--- a/src/test/java/com/herewego/herewegoapi/common/OpenAPICommunicatorTest.java
+++ b/src/test/java/com/herewego/herewegoapi/common/OpenAPICommunicatorTest.java
@@ -2,24 +2,15 @@ package com.herewego.herewegoapi.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.herewego.herewegoapi.exceptions.ForwardException;
-import com.herewego.herewegoapi.model.entity.Fixture;
-import com.herewego.herewegoapi.model.entity.FixtureStatistics;
-import com.herewego.herewegoapi.model.entity.League;
-import com.herewego.herewegoapi.model.entity.Team;
-import com.herewego.herewegoapi.repository.FIxtureStatRepository;
+import com.herewego.herewegoapi.repository.FixtureStatRepository;
 import com.herewego.herewegoapi.repository.FixtureRepository;
 import com.herewego.herewegoapi.repository.LeagueRepository;
 import com.herewego.herewegoapi.repository.TeamRepository;
-import com.herewego.herewegoapi.response.openapi.fixture.FixtureByIdResponseVO;
 import com.herewego.herewegoapi.response.openapi.fixture.Score;
-import org.assertj.core.util.DateUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.util.ObjectUtils;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class OpenAPICommunicatorTest {
@@ -31,7 +22,7 @@ public class OpenAPICommunicatorTest {
     FixtureRepository fixtureRepository;
 
     @Autowired
-    FIxtureStatRepository fixtureStatRepository;
+    FixtureStatRepository fixtureStatRepository;
 
     @Autowired
     LeagueRepository leagueRepository;

--- a/src/test/java/com/herewego/herewegoapi/service/UserServiceTest.java
+++ b/src/test/java/com/herewego/herewegoapi/service/UserServiceTest.java
@@ -1,0 +1,23 @@
+package com.herewego.herewegoapi.service;
+
+import com.herewego.herewegoapi.model.response.UserVO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    UserService userService;
+
+    @Test
+    public void getUserVOTest() {
+        //UserVO userVO = userService.getUserInformation("sukrrard97@gmail.com");
+
+        //System.out.println("test");
+    }
+}


### PR DESCRIPTION
### **Get User Info API 구현**

**API가 제공하는 데이터**
1. 처음 로그인 시에  User의 email과 account Token 반환
2. user가 등록한 home team의 정보와 team의 최근 스탯 반환 ( 기본 game 단위는 5, 10, 15 이므로 따로 설정이 없다면 최근 15경기의 데이터를 내려준다.
3. user가 등록한  favorite team의 리스트
4. user가 등록한 게임 단위 ( 현재는 게임단위 설정하는 기능은 미구현상태이므로 default로 5, 10 , 15 경기로 설정되어있다.)


**확인해야하는 사항**
- 이 API는 최초 로그인 시에 , default로 redirect 시 , 작동하는 API이다.
- API의 uri의 parameter 인 "authorization"은 auth login후에 redirect uri에 함께 타고 넘어오는 parameter 이다.  
- 위와 같은 상황에서는 Request Header의 Authorization과 Email에 어떠한 값도 넘어오지않을것이다. 관련 로직은 UserService에서 구현
- User가 이미 로그인한 상황에서 해당 API를 호출한다면 Request Header에 Authorization과 Email를 담아서 요청해야한다.