### PR TITLE
[HWG-14] feat: UserDetails 테이블 생성, UserService의 createFavoritesTeamList로직 수정

### DIFF
--- a/src/main/java/com/herewego/herewegoapi/model/entity/UserDetails.java
+++ b/src/main/java/com/herewego/herewegoapi/model/entity/UserDetails.java
@@ -1,0 +1,44 @@
+package com.herewego.herewegoapi.model.entity;
+
+import com.herewego.herewegoapi.common.AuthProvider;
+import com.herewego.herewegoapi.common.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.GenerationTime;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "UserDetails")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@DynamicInsert
+public class UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    private AuthProvider authProvider;
+
+    @Column
+    String favorites;
+
+    @org.hibernate.annotations.Generated(GenerationTime.INSERT) @Column(name = "created_date")
+    LocalDateTime createdDate;
+
+    @org.hibernate.annotations.Generated(GenerationTime.ALWAYS) @Column(name = "updated_date")
+    LocalDateTime updatedDate;
+}

--- a/src/main/java/com/herewego/herewegoapi/repository/TeamRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/TeamRepository.java
@@ -4,8 +4,13 @@ import com.herewego.herewegoapi.model.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import javax.transaction.Transactional;
+
 @Repository
 public interface TeamRepository extends JpaRepository <Team, Long> {
 
     Team findByTeamId(Integer teamId);
+
+    @Transactional
+    void deleteByTeamId(Integer teamId);
 }

--- a/src/main/java/com/herewego/herewegoapi/repository/UserDetailsRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/UserDetailsRepository.java
@@ -1,0 +1,18 @@
+package com.herewego.herewegoapi.repository;
+
+import com.herewego.herewegoapi.common.AuthProvider;
+import com.herewego.herewegoapi.model.entity.UserDetails;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+
+@Repository
+public interface UserDetailsRepository extends JpaRepository<UserDetails,Long> {
+    UserDetails findByEmail(String email);
+
+    UserDetails findByEmailAndAuthProvider(String email, AuthProvider authProvider);
+
+    @Transactional
+    void deleteByEmailAndAuthProvider(String email, AuthProvider authProvider);
+}

--- a/src/test/java/com/herewego/herewegoapi/common/Consts.java
+++ b/src/test/java/com/herewego/herewegoapi/common/Consts.java
@@ -6,4 +6,11 @@ public class Consts {
     public static final AuthProvider AUTHPROVIDER = AuthProvider.GOOGLE;
     public static final String ACCESSTOKEN = "fdsafsdierw12312";
     public static final String REFRESHTOKEN = "fsdfsdfe2312";
+    public static final UserRole ROLE = UserRole.USER;
+    public static final String FAVORITETEAM = "40,60";
+    public static final Integer TEAMID1 = 40;
+    public static final Integer TEAMID2 = 60;
+    public static final String TEAMNAME1 = "LIV";
+    public static final String TEAMNAME2  = "LEEDS";
+    public static final String LOGOURL  = "test@test.com";
 }

--- a/src/test/java/com/herewego/herewegoapi/repository/UserDetailsRepositoryTest.java
+++ b/src/test/java/com/herewego/herewegoapi/repository/UserDetailsRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.herewego.herewegoapi.repository;
+
+import com.herewego.herewegoapi.common.Consts;
+import com.herewego.herewegoapi.model.entity.Authorization;
+import com.herewego.herewegoapi.model.entity.UserDetails;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserDetailsRepositoryTest {
+
+    @Autowired
+    UserDetailsRepository userDetailsRepository;
+
+    @BeforeEach
+    public void setup() {
+        userDetailsRepository.save(UserDetails.builder()
+                .email(Consts.EMAIL)
+                .authProvider(Consts.AUTHPROVIDER)
+                .role(Consts.ROLE)
+                .favorites(Consts.FAVORITETEAM)
+                .build());
+    }
+
+    @AfterEach
+    public void teardown() {
+        userDetailsRepository.deleteByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+    }
+
+    @Test
+    void findByEmailAndAuthProviderTest() {
+        UserDetails userDetails = userDetailsRepository.findByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+
+        Assertions.assertNotNull(userDetails);
+    }
+}

--- a/src/test/java/com/herewego/herewegoapi/service/UserServiceTest.java
+++ b/src/test/java/com/herewego/herewegoapi/service/UserServiceTest.java
@@ -1,10 +1,20 @@
 package com.herewego.herewegoapi.service;
 
+import com.herewego.herewegoapi.common.Consts;
+import com.herewego.herewegoapi.model.entity.Team;
+import com.herewego.herewegoapi.model.entity.UserDetails;
+import com.herewego.herewegoapi.model.response.FavoriteTeamVO;
 import com.herewego.herewegoapi.model.response.UserVO;
+import com.herewego.herewegoapi.repository.TeamRepository;
+import com.herewego.herewegoapi.repository.UserDetailsRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,10 +24,61 @@ class UserServiceTest {
     @Autowired
     UserService userService;
 
+    @Autowired
+    UserDetailsRepository userDetailsRepository;
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    @BeforeEach
+    public void setup() {
+        userDetailsRepository.save(UserDetails.builder()
+                .email(Consts.EMAIL)
+                .authProvider(Consts.AUTHPROVIDER)
+                .role(Consts.ROLE)
+                .favorites(Consts.FAVORITETEAM)
+                .build());
+
+        teamRepository.save(Team.builder()
+                .teamId(Consts.TEAMID1)
+                .teamName(Consts.TEAMNAME1)
+                .logo(Consts.LOGOURL)
+                .build());
+
+        teamRepository.save(Team.builder()
+                .teamId(Consts.TEAMID2)
+                .teamName(Consts.TEAMNAME2)
+                .logo(Consts.LOGOURL)
+                .build());
+    }
+
+    @AfterEach
+    public void teardown() {
+        userDetailsRepository.deleteByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+        teamRepository.deleteByTeamId(Consts.TEAMID1);
+        teamRepository.deleteByTeamId(Consts.TEAMID2);
+    }
+
     @Test
     public void getUserVOTest() {
         //UserVO userVO = userService.getUserInformation("sukrrard97@gmail.com");
 
         //System.out.println("test");
+    }
+
+    @Test
+    public void getFavoriteTeamIdTest() {
+        List<Integer> favoriteTeamIdList = userService.getFavoritesTeamId(Consts.EMAIL);
+
+        Assertions.assertNotNull(favoriteTeamIdList);
+        Assertions.assertEquals(2,favoriteTeamIdList.size());
+    }
+
+    @Test
+    public void createFavoriteListTest() {
+        List<FavoriteTeamVO> favoriteTeamVOList = userService.createFavoriteList(Consts.EMAIL);
+
+        Assertions.assertNotNull(favoriteTeamVOList);
+        Assertions.assertEquals(2,favoriteTeamVOList.size());
     }
 }


### PR DESCRIPTION
### UserDetails
1. 유저의 favorite team 데이터를 저장하는 entity
2. Entity 생성 후 , jpa repository 생성 , unit test 생성


### createFavoriteTeamList
1. GET /v1/users API 호출  시, 기존에 user의 favorite team list를 임의로 넣고 있던 로직 변경
2. 1차적으로 userDetails 테이블에서 데이터를 확인 후 , user의 favorite team id 정보를 리스트로 만들어 반환
3. 2의 과정 이후 받아온 team id list를 순회하며, team 테이블에서 데이터 확인, favoriteTeamVo리스트 반환