### PR TITLE
[HWG-15] feat: Favorite team 추가 API 구현

### DIFF
--- a/src/main/java/com/herewego/herewegoapi/controller/TeamController.java
+++ b/src/main/java/com/herewego/herewegoapi/controller/TeamController.java
@@ -1,13 +1,19 @@
 package com.herewego.herewegoapi.controller;
 
 
+import com.herewego.herewegoapi.model.request.UpdateFavoriteTeamVO;
 import com.herewego.herewegoapi.response.ApiResponse;
+import com.herewego.herewegoapi.service.TeamService;
 import com.herewego.herewegoapi.vo.RegisterUserVO;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(value = "/v1")
 public class TeamController {
+    @Autowired
+    TeamService teamService;
+
     @GetMapping(value = "/teams")
     public Object getUserInformation(
             @RequestHeader(value = "Account-Token") String accountToken,
@@ -16,5 +22,16 @@ public class TeamController {
             @PathVariable("league") String leagueName)  {
 
         return ApiResponse.ok();
+    }
+
+    @PutMapping(value = "/favorites")
+    public Object updateFavoriteTeam(
+            @RequestHeader(value = "Authorization") String accountToken,
+            @RequestHeader(value = "Email") String email,
+            @RequestBody UpdateFavoriteTeamVO updateFavoriteTeamVO) {
+
+        teamService.updateFavoriteTeam(updateFavoriteTeamVO.getTeamName(), updateFavoriteTeamVO.getLeagueName());
+        return ApiResponse.ok();
+
     }
 }

--- a/src/main/java/com/herewego/herewegoapi/controller/TeamController.java
+++ b/src/main/java/com/herewego/herewegoapi/controller/TeamController.java
@@ -1,6 +1,7 @@
 package com.herewego.herewegoapi.controller;
 
 
+import com.herewego.herewegoapi.exceptions.ForwardException;
 import com.herewego.herewegoapi.model.request.UpdateFavoriteTeamVO;
 import com.herewego.herewegoapi.response.ApiResponse;
 import com.herewego.herewegoapi.service.TeamService;
@@ -28,9 +29,9 @@ public class TeamController {
     public Object updateFavoriteTeam(
             @RequestHeader(value = "Authorization") String accountToken,
             @RequestHeader(value = "Email") String email,
-            @RequestBody UpdateFavoriteTeamVO updateFavoriteTeamVO) {
+            @RequestBody UpdateFavoriteTeamVO updateFavoriteTeamVO) throws ForwardException {
 
-        teamService.updateFavoriteTeam(updateFavoriteTeamVO.getTeamName(), updateFavoriteTeamVO.getLeagueName());
+        teamService.updateFavoriteTeam(email, updateFavoriteTeamVO.getTeamName(), updateFavoriteTeamVO.getLeagueName());
         return ApiResponse.ok();
 
     }

--- a/src/main/java/com/herewego/herewegoapi/model/request/UpdateFavoriteTeamVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/request/UpdateFavoriteTeamVO.java
@@ -1,0 +1,18 @@
+package com.herewego.herewegoapi.model.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UpdateFavoriteTeamVO {
+    String teamName;
+
+    String leagueName;
+}

--- a/src/main/java/com/herewego/herewegoapi/repository/TeamRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/TeamRepository.java
@@ -11,6 +11,8 @@ public interface TeamRepository extends JpaRepository <Team, Long> {
 
     Team findByTeamId(Integer teamId);
 
+    Team findByTeamName(String teamName);
+
     @Transactional
     void deleteByTeamId(Integer teamId);
 }

--- a/src/main/java/com/herewego/herewegoapi/service/TeamService.java
+++ b/src/main/java/com/herewego/herewegoapi/service/TeamService.java
@@ -1,0 +1,12 @@
+package com.herewego.herewegoapi.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TeamService {
+
+    public void updateFavoriteTeam(String teamName, String leagueName) {
+        
+    }
+}

--- a/src/main/java/com/herewego/herewegoapi/service/TeamService.java
+++ b/src/main/java/com/herewego/herewegoapi/service/TeamService.java
@@ -1,12 +1,56 @@
 package com.herewego.herewegoapi.service;
 
+import com.herewego.herewegoapi.exceptions.ErrorCode;
+import com.herewego.herewegoapi.exceptions.ForwardException;
+import com.herewego.herewegoapi.model.entity.Team;
+import com.herewego.herewegoapi.model.entity.UserDetails;
+import com.herewego.herewegoapi.repository.TeamRepository;
+import com.herewego.herewegoapi.repository.UserDetailsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.swing.text.html.Option;
+import java.util.Optional;
+import java.util.OptionalInt;
+
 @Service
 public class TeamService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TeamService.class);
 
-    public void updateFavoriteTeam(String teamName, String leagueName) {
-        
+    @Autowired
+    UserDetailsRepository userDetailsRepository;
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    //TODO: 이후 팀과 리그간의 관계가 맺어진다면 수정해야한다.
+    public void updateFavoriteTeam(String email, String teamName, String leagueName) throws ForwardException {
+        Optional<Team>optional = Optional.ofNullable(teamRepository.findByTeamName(teamName));
+
+        Team team = optional.orElseThrow(()->{
+            LOGGER.debug("Cannot found team by teamName {}",teamName);
+           return new ForwardException(ErrorCode.RC400000,"Invalid Team");
+        });
+        LOGGER.debug("Team Name : {}",team.getTeamName());
+
+        updateUserDetails(email, team.getTeamId());
+        return;
+    }
+
+    private void updateUserDetails(String email, Integer teamId) throws ForwardException {
+        Optional<UserDetails> userDetailsOptional = Optional.ofNullable(userDetailsRepository.findByEmail(email));
+
+        UserDetails userDetails = userDetailsOptional.orElseThrow(()->{
+            LOGGER.debug("Cannot found user details by Email {}",email);
+            return new ForwardException(ErrorCode.RC400000,"Invalid User Email");
+        });
+
+        String favoriteTeamList = userDetails.getFavorites();
+        favoriteTeamList += "," + teamId.toString();
+        userDetails.setFavorites(favoriteTeamList);
+        userDetailsRepository.save(userDetails);
+        return;
     }
 }

--- a/src/main/java/com/herewego/herewegoapi/service/TeamService.java
+++ b/src/main/java/com/herewego/herewegoapi/service/TeamService.java
@@ -11,9 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 @Service
 public class TeamService {

--- a/src/test/java/com/herewego/herewegoapi/common/Consts.java
+++ b/src/test/java/com/herewego/herewegoapi/common/Consts.java
@@ -8,9 +8,11 @@ public class Consts {
     public static final String REFRESHTOKEN = "fsdfsdfe2312";
     public static final UserRole ROLE = UserRole.USER;
     public static final String FAVORITETEAM = "40,60";
+    public static final String FAVORITETEAM2 = "40";
     public static final Integer TEAMID1 = 40;
     public static final Integer TEAMID2 = 60;
     public static final String TEAMNAME1 = "LIV";
     public static final String TEAMNAME2  = "LEEDS";
     public static final String LOGOURL  = "test@test.com";
+    public static final String LEAGUENAME = "Premier League";
 }

--- a/src/test/java/com/herewego/herewegoapi/service/TeamServiceTest.java
+++ b/src/test/java/com/herewego/herewegoapi/service/TeamServiceTest.java
@@ -1,0 +1,65 @@
+package com.herewego.herewegoapi.service;
+
+import com.herewego.herewegoapi.common.Consts;
+import com.herewego.herewegoapi.exceptions.ForwardException;
+import com.herewego.herewegoapi.model.entity.Team;
+import com.herewego.herewegoapi.model.entity.UserDetails;
+import com.herewego.herewegoapi.repository.TeamRepository;
+import com.herewego.herewegoapi.repository.UserDetailsRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+class TeamServiceTest {
+    @Autowired
+    TeamService teamService;
+
+    @Autowired
+    UserDetailsRepository userDetailsRepository;
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    @BeforeEach
+    public void setup() {
+        userDetailsRepository.save(UserDetails.builder()
+                .email(Consts.EMAIL)
+                .authProvider(Consts.AUTHPROVIDER)
+                .role(Consts.ROLE)
+                .favorites(Consts.FAVORITETEAM2)
+                .build());
+
+        teamRepository.save(Team.builder()
+                .teamId(Consts.TEAMID1)
+                .teamName(Consts.TEAMNAME1)
+                .logo(Consts.LOGOURL)
+                .build());
+
+        teamRepository.save(Team.builder()
+                .teamId(Consts.TEAMID2)
+                .teamName(Consts.TEAMNAME2)
+                .logo(Consts.LOGOURL)
+                .build());
+    }
+    @AfterEach
+    public void teardown() {
+        userDetailsRepository.deleteByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+        teamRepository.deleteByTeamId(Consts.TEAMID1);
+        teamRepository.deleteByTeamId(Consts.TEAMID2);
+    }
+
+
+    @Test
+    void updateFavoriteTeamTest_success() throws ForwardException {
+        teamService.updateFavoriteTeam(Consts.EMAIL, Consts.TEAMNAME2, Consts.LEAGUENAME);
+
+        UserDetails userDetails = userDetailsRepository.findByEmail(Consts.EMAIL);
+        Assertions.assertNotNull(userDetails);
+        Assertions.assertEquals(userDetails.getFavorites(), Consts.FAVORITETEAM);
+    }
+}


### PR DESCRIPTION
PUT /v1/favorites 구현

1. Client에서 PUT 요청으로 TeamName과 LeagueName을 body 에 담아서 요청하면,
2. 요청한 팀이 즐겨찾기하는 팀으로  유저정보에 등록되었다는 데이터를 저장한다.