### PR TITLE
[HWG-16] feat: Oauth2 logic 수정

### DIFF
--- a/src/main/java/com/herewego/herewegoapi/common/AuthProvider.java
+++ b/src/main/java/com/herewego/herewegoapi/common/AuthProvider.java
@@ -1,5 +1,5 @@
 package com.herewego.herewegoapi.common;
 
 public enum AuthProvider {
-    GOOGLE, GITHUB
+    GOOGLE, GITHUB, NONE
 }

--- a/src/main/java/com/herewego/herewegoapi/config/SecurityConfig.java
+++ b/src/main/java/com/herewego/herewegoapi/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/oauth2/**", "/auth/**").permitAll()
                 .antMatchers("/test").permitAll()
                 .antMatchers("/health").permitAll()
+                .antMatchers("/v1/join").permitAll()
                 .antMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated();
 

--- a/src/main/java/com/herewego/herewegoapi/controller/UserController.java
+++ b/src/main/java/com/herewego/herewegoapi/controller/UserController.java
@@ -4,8 +4,11 @@ import com.herewego.herewegoapi.model.entity.User;
 import com.herewego.herewegoapi.repository.UserRepository;
 import com.herewego.herewegoapi.response.ApiResponse;
 import com.herewego.herewegoapi.security.CustomUserDetails;
+import com.herewego.herewegoapi.security.oauth.CustomOAuth2UserService;
 import com.herewego.herewegoapi.service.UserService;
 import com.herewego.herewegoapi.vo.RegisterUserVO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping(value = "/v1")
 public class UserController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserController.class);
 
     @Autowired
     UserRepository userRepository;
@@ -21,13 +25,16 @@ public class UserController {
     @Autowired
     UserService userService;
 
-    @PostMapping(value = "/users")
-    public Object registerUser(
-            @RequestHeader(value = "Account-Token") String accountToken,
-            @RequestHeader(value = "Account-Id") String accountId,
-            @RequestBody RegisterUserVO registerUserVO) {
+    @Autowired
+    CustomOAuth2UserService customOAuth2UserService;
 
-        return ApiResponse.ok();
+    @GetMapping(value = "/join")
+    public Object registerUser(
+//            @RequestHeader(value = "Access-Token") String accountToken,
+//            @RequestHeader(value = "Email") String email) {
+    ){
+        LOGGER.debug("GET 요청 /v1/join");
+        return customOAuth2UserService.login("GOOGLE");
     }
 
     //Parameter로 들어오는 authorization은 재인증 시에 redirect url에 토큰을 담아서 요청하기 때문에 받아온다.

--- a/src/main/java/com/herewego/herewegoapi/controller/UserController.java
+++ b/src/main/java/com/herewego/herewegoapi/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.herewego.herewegoapi.controller;
 
+import com.herewego.herewegoapi.exceptions.ForwardException;
 import com.herewego.herewegoapi.model.entity.User;
+import com.herewego.herewegoapi.model.request.JoinRequestVO;
 import com.herewego.herewegoapi.repository.UserRepository;
 import com.herewego.herewegoapi.response.ApiResponse;
 import com.herewego.herewegoapi.security.CustomUserDetails;
@@ -28,23 +30,22 @@ public class UserController {
     @Autowired
     CustomOAuth2UserService customOAuth2UserService;
 
-    @GetMapping(value = "/join")
+    @PostMapping(value = "/join")
     public Object registerUser(
-//            @RequestHeader(value = "Access-Token") String accountToken,
-//            @RequestHeader(value = "Email") String email) {
-    ){
+            @RequestHeader(value = "Access-Token") String accessToken,
+            @RequestHeader(value = "Refresh-Token") String refreshToken,
+            @RequestBody JoinRequestVO joinVO) throws ForwardException {
         LOGGER.debug("GET 요청 /v1/join");
-        return customOAuth2UserService.login("GOOGLE");
+        return customOAuth2UserService.login(accessToken, refreshToken, joinVO);
     }
 
-    //Parameter로 들어오는 authorization은 재인증 시에 redirect url에 토큰을 담아서 요청하기 때문에 받아온다.
     @GetMapping(value = "/users")
     public Object getUserInformation(
-            @RequestHeader(required = false, value = "Authorization") String accountToken,
+            @RequestHeader(required = false, value = "UserId") String userId,
             @RequestHeader(required = false, value = "Email") String email,
-            @RequestParam(required = false, value = "authorization") String accountTokenParam) {
+            @RequestHeader(required = false, value = "Authorization") String accountToken) {
 
-        return userService.getUserInformation(email, accountToken, accountTokenParam);
+        return userService.getUserInformation(userId, accountToken);
     }
 
     @PutMapping(value = "/users/gameunit")

--- a/src/main/java/com/herewego/herewegoapi/model/entity/Authorization.java
+++ b/src/main/java/com/herewego/herewegoapi/model/entity/Authorization.java
@@ -22,8 +22,8 @@ public class Authorization {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
-    @Column(unique = true, nullable = false)
-    private String email;
+    @Column(unique = true, nullable = false, name = "user_id")
+    private String userId;
 
     @Enumerated(EnumType.STRING)
     private AuthProvider authProvider;

--- a/src/main/java/com/herewego/herewegoapi/model/entity/User.java
+++ b/src/main/java/com/herewego/herewegoapi/model/entity/User.java
@@ -24,10 +24,13 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
+    @Column(unique = true,nullable = false, name = "user_id")
+    private String userId;
+
     @Column(unique = true, nullable = false)
     private String email;
 
-    @Column(unique = true)
+    @Column()
     private String name;
 
     private String description;

--- a/src/main/java/com/herewego/herewegoapi/model/entity/UserDetails.java
+++ b/src/main/java/com/herewego/herewegoapi/model/entity/UserDetails.java
@@ -24,14 +24,8 @@ public class UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
-    @Column(unique = true, nullable = false)
-    private String email;
-
-    @Enumerated(EnumType.STRING)
-    private UserRole role;
-
-    @Enumerated(EnumType.STRING)
-    private AuthProvider authProvider;
+    @Column(unique = true, nullable = false, name = "user_id")
+    private String userId;
 
     @Column
     String favorites;

--- a/src/main/java/com/herewego/herewegoapi/model/request/JoinRequestVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/request/JoinRequestVO.java
@@ -1,0 +1,23 @@
+package com.herewego.herewegoapi.model.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.herewego.herewegoapi.common.AuthProvider;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JoinRequestVO {
+    AuthProvider authProvider;
+
+    String email;
+
+    String name;
+
+    String image;
+}

--- a/src/main/java/com/herewego/herewegoapi/model/response/GoogleOauthGetUserInfoResponseVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/response/GoogleOauthGetUserInfoResponseVO.java
@@ -1,0 +1,18 @@
+package com.herewego.herewegoapi.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GoogleOauthGetUserInfoResponseVO {
+    String user_id;
+    String email;
+    String issuer;
+}

--- a/src/main/java/com/herewego/herewegoapi/model/response/JoinResponseVO.java
+++ b/src/main/java/com/herewego/herewegoapi/model/response/JoinResponseVO.java
@@ -1,0 +1,18 @@
+package com.herewego.herewegoapi.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JoinResponseVO {
+    String jwtAccessToken;
+
+    String jwtRefreshToken;
+}

--- a/src/main/java/com/herewego/herewegoapi/repository/AuthorizationRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/AuthorizationRepository.java
@@ -20,20 +20,20 @@ public interface AuthorizationRepository extends JpaRepository<Authorization, Lo
 
     @Transactional
     @Modifying
-    @Query("UPDATE Authorization u SET u.refreshToken=:token WHERE u.email=:email")
-    void updateRefreshToken(@Param("email") String email, @Param("token") String token);
+    @Query("UPDATE Authorization u SET u.refreshToken=:token WHERE u.userId=:userId")
+    void updateRefreshToken(@Param("userId") String userId, @Param("token") String token);
 
     @Transactional
     @Modifying
-    @Query("UPDATE Authorization u SET u.accessToken=:token WHERE u.email=:email")
-    void updateAccessToken(@Param("email") String email, @Param("token") String token);
-
-    Authorization findByEmailAndAuthProvider(String email, AuthProvider authProvider);
+    @Query("UPDATE Authorization u SET u.accessToken=:token WHERE u.userId=:userId")
+    void updateAccessToken(@Param("userId") String userId, @Param("token") String token);
 
     Authorization findByAccessToken(String accessToken);
 
+    Authorization findByUserId(String userId);
+
     @Transactional
-    void deleteByEmailAndAuthProvider(String email, AuthProvider authProvider);
+    void deleteByUserId(String userId);
 
 
 }

--- a/src/main/java/com/herewego/herewegoapi/repository/UserDetailsRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/UserDetailsRepository.java
@@ -9,10 +9,9 @@ import javax.transaction.Transactional;
 
 @Repository
 public interface UserDetailsRepository extends JpaRepository<UserDetails,Long> {
-    UserDetails findByEmail(String email);
 
-    UserDetails findByEmailAndAuthProvider(String email, AuthProvider authProvider);
+    UserDetails findByUserId(String userId);
 
     @Transactional
-    void deleteByEmailAndAuthProvider(String email, AuthProvider authProvider);
+    void deleteByUserId(String useId);
 }

--- a/src/main/java/com/herewego/herewegoapi/repository/UserRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/UserRepository.java
@@ -14,5 +14,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByUserId(String userId);
+
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/herewego/herewegoapi/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/herewego/herewegoapi/security/jwt/JwtAuthenticationFilter.java
@@ -35,7 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         ObjectMapper mapper = new ObjectMapper();
 
-        if (!"/test".equals(path) && !"/health".equals(path) && !"/favicon.ico".equals(path)) {
+        if (!"/test".equals(path) && !"/health".equals(path) && !"/favicon.ico".equals(path) && !"/v1/join".equals(path)) {
             String token = parseBearerToken(request);
             LOGGER.debug("Authorization: {}", token);
 

--- a/src/main/java/com/herewego/herewegoapi/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/herewego/herewegoapi/security/oauth/CustomOAuth2UserService.java
@@ -89,7 +89,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         } else {			// 가입되지 않은 경우
             userRepository.save(user);
             createAuthroization(user, accessJwtToken, refreshJwtToken);
-            createUserDetails(user);
         }
 
         return JoinResponseVO.builder()

--- a/src/main/java/com/herewego/herewegoapi/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/herewego/herewegoapi/security/oauth/CustomOAuth2UserService.java
@@ -2,8 +2,6 @@ package com.herewego.herewegoapi.security.oauth;
 
 import com.herewego.herewegoapi.common.AuthProvider;
 import com.herewego.herewegoapi.common.UserRole;
-import com.herewego.herewegoapi.exceptions.ErrorCode;
-import com.herewego.herewegoapi.exceptions.ForwardException;
 import com.herewego.herewegoapi.exceptions.OAuthProcessingException;
 import com.herewego.herewegoapi.model.entity.Authorization;
 import com.herewego.herewegoapi.model.entity.User;
@@ -12,24 +10,32 @@ import com.herewego.herewegoapi.repository.UserRepository;
 import com.herewego.herewegoapi.security.CustomUserDetails;
 import com.herewego.herewegoapi.security.oauth.user.OAuth2UserInfo;
 import com.herewego.herewegoapi.security.oauth.user.OAuth2UserInfoFactory;
-import lombok.SneakyThrows;
+import com.nimbusds.oauth2.sdk.token.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import javax.transaction.Transactional;
+import java.util.Map;
 import java.util.Optional;
 
 
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private static final Logger LOGGER = LoggerFactory.getLogger(CustomOAuth2UserService.class);
+
+    @Autowired
+    InMemoryClientRegistrationRepository inMemoryClientRegistrationRepository;
 
     @Autowired
     UserRepository userRepository;
@@ -50,10 +56,30 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
     }
 
+    @Transactional
+    public Token login(String providerName) { //로그인 로직 모두 처리하는 메서드
+        ClientRegistration provider = inMemoryClientRegistrationRepository.findByRegistrationId(providerName);
+
+        LOGGER.debug("clientRegistration provider : {}", provider.getProviderDetails().getAuthorizationUri());
+        LOGGER.debug("redirect uri : {}", provider.getRedirectUri());
+        LOGGER.debug("userInfoEndpoint uri: {}", provider.getProviderDetails().getUserInfoEndpoint().getUri());
+
+//        //kakao로부터 유저정보 받아서 db에 저장
+//        User user = getUserProfile(providerName, tokenResponse, provider);
+//
+//        //jwt token 발급
+//        String accessToken = tokenProvider.createAccessToken(user);
+//        String refreshToken = tokenProvider.createRefreshToken(user);
+//        Token token = new Token(accessToken,refreshToken);
+//        return token;
+        Token token=null;
+        return token;
+    }
+
     // 획득한 유저정보를 Java Model과 맵핑하고 프로세스 진행
     private OAuth2User process(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) throws OAuthProcessingException {
-        AuthProvider authProvider = AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId().toUpperCase());
-        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(authProvider, oAuth2User.getAttributes());
+            AuthProvider authProvider = AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId().toUpperCase());
+            OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(authProvider, oAuth2User.getAttributes());
 
         LOGGER.debug("accessToken은 : {}", oAuth2UserRequest.getAccessToken().toString());
 
@@ -95,4 +121,42 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .build());
         }
     }
+
+
+    //google로부터 User Resource를 전달받음
+    private Map<String, Object> getUserAttributes(ClientRegistration provider, OAuth2AccessTokenResponse tokenResponse) {
+        return WebClient.create()
+                .get()
+                .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
+                .headers(header -> header.setBearerAuth(tokenResponse.getAccessToken().getTokenValue()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+
+//    private User getUserProfile(AuthProvider provider, OAuth2AccessTokenResponse auth2AccessTokenResponse) throws OAuthProcessingException {
+//        Map<String, Object> userAttributes = getUserAttributes(provider, auth2AccessTokenResponse);
+//        String userNameAttributeName = provider.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+//        OAuth2UserInfo attributes = OAuth2UserInfo.of(providerName.toUpperCase(), userNameAttributeName, userAttributes);
+//        if(attributes.getEmail().isEmpty()) {
+//            throw new OAuthProcessingException("Email not found from OAuth2 provider");
+//        }
+//
+//        Optional<User> userOptional = userRepository.findByEmail(attributes.getEmail());
+//        User user;
+//
+//        //이미 가입된 경우
+//        if(userOptional.isPresent()){
+//            user = userOptional.get();
+//            if(AuthProvider.valueOf(provider.toString()) != user.getAuthProvider()) {
+//                throw new OAuthProcessingException("Wrong Match Auth Provider");
+//            }
+//        } else {
+//            //첫 로그인인 경우
+//            user = createUser(attributes,AuthProvider.valueOf((provider.toString()));
+//        }
+//
+//        CustomUserDetails.create(user,userAttributes);
+//        return user;
+//    }
 }

--- a/src/main/java/com/herewego/herewegoapi/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/herewego/herewegoapi/security/oauth/CustomOAuth2UserService.java
@@ -2,31 +2,35 @@ package com.herewego.herewegoapi.security.oauth;
 
 import com.herewego.herewegoapi.common.AuthProvider;
 import com.herewego.herewegoapi.common.UserRole;
+import com.herewego.herewegoapi.common.WebClientBuilderManager;
+import com.herewego.herewegoapi.exceptions.ErrorCode;
+import com.herewego.herewegoapi.exceptions.ForwardException;
 import com.herewego.herewegoapi.exceptions.OAuthProcessingException;
 import com.herewego.herewegoapi.model.entity.Authorization;
 import com.herewego.herewegoapi.model.entity.User;
+import com.herewego.herewegoapi.model.entity.UserDetails;
+import com.herewego.herewegoapi.model.request.JoinRequestVO;
+import com.herewego.herewegoapi.model.response.GoogleOauthGetUserInfoResponseVO;
+import com.herewego.herewegoapi.model.response.JoinResponseVO;
 import com.herewego.herewegoapi.repository.AuthorizationRepository;
+import com.herewego.herewegoapi.repository.UserDetailsRepository;
 import com.herewego.herewegoapi.repository.UserRepository;
 import com.herewego.herewegoapi.security.CustomUserDetails;
+import com.herewego.herewegoapi.security.jwt.JwtTokenProvider;
 import com.herewego.herewegoapi.security.oauth.user.OAuth2UserInfo;
 import com.herewego.herewegoapi.security.oauth.user.OAuth2UserInfoFactory;
-import com.nimbusds.oauth2.sdk.token.Token;
+import com.herewego.herewegoapi.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import javax.transaction.Transactional;
-import java.util.Map;
+import java.time.Duration;
 import java.util.Optional;
 
 
@@ -34,14 +38,26 @@ import java.util.Optional;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private static final Logger LOGGER = LoggerFactory.getLogger(CustomOAuth2UserService.class);
 
-    @Autowired
-    InMemoryClientRegistrationRepository inMemoryClientRegistrationRepository;
+    private static final String OAUTH2_GET_USERINFO_URI = "https://www.googleapis.com/oauth2/v1/tokeninfo?id_token=";
+    private static final String GOOGLE_ISSUER = "https://accounts.google.com";
 
     @Autowired
     UserRepository userRepository;
 
     @Autowired
     AuthorizationRepository authorizationRepository;
+
+    @Autowired
+    UserDetailsRepository userDetailsRepository;
+
+    @Autowired
+    WebClientBuilderManager webClientBuilderManager;
+
+    @Autowired
+    JwtTokenProvider tokenProvider;
+
+    @Autowired
+    UserService userService;
 
     // OAuth2UserRequest에 있는 Access Token으로 유저정보 get
     @Override
@@ -52,31 +68,38 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             return process(oAuth2UserRequest, oAuth2User);
         } catch (OAuthProcessingException e) {
             e.printStackTrace();
-            return null;
-        }
+        return null;
     }
+}
 
     @Transactional
-    public Token login(String providerName) { //로그인 로직 모두 처리하는 메서드
-        ClientRegistration provider = inMemoryClientRegistrationRepository.findByRegistrationId(providerName);
+    public JoinResponseVO login(String accessToken, String refreshToken, JoinRequestVO joinVO) throws ForwardException { //로그인 로직 모두 처리하는 메서드
+        //google로부터 유저정보 받아서 db에 저장
+        User user = getGoogleUserInfo(accessToken, refreshToken, joinVO);
+        LOGGER.debug("Google User Email is {}", user.getEmail());
 
-        LOGGER.debug("clientRegistration provider : {}", provider.getProviderDetails().getAuthorizationUri());
-        LOGGER.debug("redirect uri : {}", provider.getRedirectUri());
-        LOGGER.debug("userInfoEndpoint uri: {}", provider.getProviderDetails().getUserInfoEndpoint().getUri());
+        //jwt token 발급
+        String accessJwtToken = tokenProvider.createJWTAccessToken(user);
+        String refreshJwtToken = tokenProvider.createRefreshJWTToken(user);
 
-//        //kakao로부터 유저정보 받아서 db에 저장
-//        User user = getUserProfile(providerName, tokenResponse, provider);
-//
-//        //jwt token 발급
-//        String accessToken = tokenProvider.createAccessToken(user);
-//        String refreshToken = tokenProvider.createRefreshToken(user);
-//        Token token = new Token(accessToken,refreshToken);
-//        return token;
-        Token token=null;
-        return token;
+        Optional<User> userOptional = userRepository.findByUserId(user.getUserId());
+        if (userOptional.isPresent()) {		// 이미 가입된 경우
+            user = userOptional.get();
+            updateAuthroization(user, accessJwtToken, refreshJwtToken);
+        } else {			// 가입되지 않은 경우
+            userRepository.save(user);
+            createAuthroization(user, accessJwtToken, refreshJwtToken);
+            createUserDetails(user);
+        }
+
+        return JoinResponseVO.builder()
+                .jwtAccessToken(accessJwtToken)
+                .jwtRefreshToken(refreshJwtToken)
+                .build();
     }
 
     // 획득한 유저정보를 Java Model과 맵핑하고 프로세스 진행
+    //TODO : DEPRECATED
     private OAuth2User process(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) throws OAuthProcessingException {
             AuthProvider authProvider = AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId().toUpperCase());
             OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(authProvider, oAuth2User.getAttributes());
@@ -101,6 +124,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return CustomUserDetails.create(user, oAuth2User.getAttributes());
     }
 
+    //TODO : DEPRECATED
     private User createUser(OAuth2UserInfo userInfo, AuthProvider authProvider) {
         User user = User.builder()
                 .email(userInfo.getEmail())
@@ -112,51 +136,79 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return userRepository.save(user);
     }
 
+    //TODO : DEPRECATED
     private void createAuthorization(OAuth2UserInfo userInfo, AuthProvider authProvider) {
-        Authorization authorization= authorizationRepository.findByEmailAndAuthProvider(userInfo.getEmail(), authProvider);
-        if (ObjectUtils.isEmpty(authorization)) {
-            authorizationRepository.save(Authorization.builder()
-                    .email(userInfo.getEmail())
-                    .authProvider(authProvider)
+//        Authorization authorization= authorizationRepository.findByEmailAndAuthProvider(userInfo.getEmail(), authProvider);
+//        if (ObjectUtils.isEmpty(authorization)) {
+//            authorizationRepository.save(Authorization.builder()
+//                    .email(userInfo.getEmail())
+//                    .authProvider(authProvider)
+//                    .build());
+//        }
+    }
+
+    private void createUserDetails(User user){
+        UserDetails userDetails= userDetailsRepository.findByUserId(user.getUserId());
+        if (ObjectUtils.isEmpty(userDetails)) {
+            userDetailsRepository.save(UserDetails.builder()
+                    .userId(user.getUserId())
                     .build());
         }
     }
 
-
-    //google로부터 User Resource를 전달받음
-    private Map<String, Object> getUserAttributes(ClientRegistration provider, OAuth2AccessTokenResponse tokenResponse) {
-        return WebClient.create()
-                .get()
-                .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
-                .headers(header -> header.setBearerAuth(tokenResponse.getAccessToken().getTokenValue()))
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
-                .block();
+    private void createAuthroization(User user, String accessToken, String refreshToken){
+        Authorization authorization= authorizationRepository.findByUserId(user.getUserId());
+        if (ObjectUtils.isEmpty(authorization)) {
+            authorizationRepository.save(Authorization.builder()
+                    .userId(user.getUserId())
+                    .authProvider(user.getAuthProvider())
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build());
+        }
     }
 
-//    private User getUserProfile(AuthProvider provider, OAuth2AccessTokenResponse auth2AccessTokenResponse) throws OAuthProcessingException {
-//        Map<String, Object> userAttributes = getUserAttributes(provider, auth2AccessTokenResponse);
-//        String userNameAttributeName = provider.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
-//        OAuth2UserInfo attributes = OAuth2UserInfo.of(providerName.toUpperCase(), userNameAttributeName, userAttributes);
-//        if(attributes.getEmail().isEmpty()) {
-//            throw new OAuthProcessingException("Email not found from OAuth2 provider");
-//        }
-//
-//        Optional<User> userOptional = userRepository.findByEmail(attributes.getEmail());
-//        User user;
-//
-//        //이미 가입된 경우
-//        if(userOptional.isPresent()){
-//            user = userOptional.get();
-//            if(AuthProvider.valueOf(provider.toString()) != user.getAuthProvider()) {
-//                throw new OAuthProcessingException("Wrong Match Auth Provider");
-//            }
-//        } else {
-//            //첫 로그인인 경우
-//            user = createUser(attributes,AuthProvider.valueOf((provider.toString()));
-//        }
-//
-//        CustomUserDetails.create(user,userAttributes);
-//        return user;
-//    }
+    private void updateAuthroization(User user, String accessToken, String refreshToken){
+        authorizationRepository.updateAccessToken(user.getUserId(), accessToken);
+        authorizationRepository.updateRefreshToken(user.getUserId(), refreshToken);
+    }
+
+    private User getGoogleUserInfo(String accessToken, String refreshToken, JoinRequestVO joinVO) throws ForwardException {
+        GoogleOauthGetUserInfoResponseVO googleOauthGetUserInfoResponseVO = webClientBuilderManager
+                .makeCommonWebclientBuilder()
+                .build()
+                .get()
+                .uri(OAUTH2_GET_USERINFO_URI + accessToken)
+                .retrieve()
+                .bodyToMono(GoogleOauthGetUserInfoResponseVO.class)
+                .block(Duration.ofSeconds(60L));
+
+        User user = User.builder()
+                .email(googleOauthGetUserInfoResponseVO.getEmail())
+                .userId(googleOauthGetUserInfoResponseVO.getUser_id())
+                .role(UserRole.USER)
+                .authProvider(googleOauthGetUserInfoResponseVO.getIssuer().equals(GOOGLE_ISSUER)?AuthProvider.GOOGLE:AuthProvider.NONE)
+                .build();
+
+        if (validateGoogleUserInfo(user, joinVO)) {
+            user.setName(joinVO.getName());
+            user.setImg(joinVO.getImage());
+            return user;
+        }
+        throw new ForwardException(ErrorCode.RC400000, "Invalid User Information");
+    }
+
+    private boolean validateGoogleUserInfo(User user, JoinRequestVO joinVO){
+        if (!user.getEmail().equals(joinVO.getEmail())) {
+            LOGGER.debug("Invalid Email");
+            return false;
+        }
+
+        if(!user.getAuthProvider().equals(joinVO.getAuthProvider())) {
+            LOGGER.debug("Invalid Auth Provder");
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/main/java/com/herewego/herewegoapi/service/TeamService.java
+++ b/src/main/java/com/herewego/herewegoapi/service/TeamService.java
@@ -38,7 +38,7 @@ public class TeamService {
     }
 
     private void updateUserDetails(String email, Integer teamId) throws ForwardException {
-        Optional<UserDetails> userDetailsOptional = Optional.ofNullable(userDetailsRepository.findByEmail(email));
+        Optional<UserDetails> userDetailsOptional = Optional.ofNullable(userDetailsRepository.findByUserId(email));
 
         UserDetails userDetails = userDetailsOptional.orElseThrow(()->{
             LOGGER.debug("Cannot found user details by Email {}",email);

--- a/src/test/java/com/herewego/herewegoapi/common/Consts.java
+++ b/src/test/java/com/herewego/herewegoapi/common/Consts.java
@@ -2,6 +2,7 @@ package com.herewego.herewegoapi.common;
 
 
 public class Consts {
+    public static final String USERID="testid";
     public static final String EMAIL = "testEmail@gmail.com";
     public static final AuthProvider AUTHPROVIDER = AuthProvider.GOOGLE;
     public static final String ACCESSTOKEN = "fdsafsdierw12312";

--- a/src/test/java/com/herewego/herewegoapi/repository/AuthorizationRepositoryTest.java
+++ b/src/test/java/com/herewego/herewegoapi/repository/AuthorizationRepositoryTest.java
@@ -20,21 +20,19 @@ class AuthorizationRepositoryTest {
     @BeforeEach
     public void setup() {
         authorizationRepository.save(Authorization.builder()
-                .email(Consts.EMAIL)
-                .authProvider(Consts.AUTHPROVIDER)
-                .refreshToken(Consts.REFRESHTOKEN)
+                .userId(Consts.USERID)
                 .accessToken(Consts.ACCESSTOKEN)
                 .build());
     }
 
     @AfterEach
     public void teardown() {
-        authorizationRepository.deleteByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+        authorizationRepository.deleteByUserId(Consts.USERID);
     }
 
     @Test
     void findByEmailAndAuthProvider() {
-        Authorization authorization = authorizationRepository.findByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+        Authorization authorization = authorizationRepository.findByUserId(Consts.USERID);
 
         Assertions.assertNotNull(authorization);
     }

--- a/src/test/java/com/herewego/herewegoapi/repository/UserDetailsRepositoryTest.java
+++ b/src/test/java/com/herewego/herewegoapi/repository/UserDetailsRepositoryTest.java
@@ -21,21 +21,19 @@ class UserDetailsRepositoryTest {
     @BeforeEach
     public void setup() {
         userDetailsRepository.save(UserDetails.builder()
-                .email(Consts.EMAIL)
-                .authProvider(Consts.AUTHPROVIDER)
-                .role(Consts.ROLE)
+                .userId(Consts.USERID)
                 .favorites(Consts.FAVORITETEAM)
                 .build());
     }
 
     @AfterEach
     public void teardown() {
-        userDetailsRepository.deleteByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+        userDetailsRepository.deleteByUserId(Consts.USERID);
     }
 
     @Test
-    void findByEmailAndAuthProviderTest() {
-        UserDetails userDetails = userDetailsRepository.findByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+    void findByUserIdTest() {
+        UserDetails userDetails = userDetailsRepository.findByUserId(Consts.USERID);
 
         Assertions.assertNotNull(userDetails);
     }

--- a/src/test/java/com/herewego/herewegoapi/service/TeamServiceTest.java
+++ b/src/test/java/com/herewego/herewegoapi/service/TeamServiceTest.java
@@ -28,9 +28,7 @@ class TeamServiceTest {
     @BeforeEach
     public void setup() {
         userDetailsRepository.save(UserDetails.builder()
-                .email(Consts.EMAIL)
-                .authProvider(Consts.AUTHPROVIDER)
-                .role(Consts.ROLE)
+                .userId(Consts.EMAIL)
                 .favorites(Consts.FAVORITETEAM2)
                 .build());
 
@@ -48,7 +46,7 @@ class TeamServiceTest {
     }
     @AfterEach
     public void teardown() {
-        userDetailsRepository.deleteByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+        userDetailsRepository.deleteByUserId(Consts.USERID);
         teamRepository.deleteByTeamId(Consts.TEAMID1);
         teamRepository.deleteByTeamId(Consts.TEAMID2);
     }
@@ -58,7 +56,7 @@ class TeamServiceTest {
     void updateFavoriteTeamTest_success() throws ForwardException {
         teamService.updateFavoriteTeam(Consts.EMAIL, Consts.TEAMNAME2, Consts.LEAGUENAME);
 
-        UserDetails userDetails = userDetailsRepository.findByEmail(Consts.EMAIL);
+        UserDetails userDetails = userDetailsRepository.findByUserId(Consts.USERID);
         Assertions.assertNotNull(userDetails);
         Assertions.assertEquals(userDetails.getFavorites(), Consts.FAVORITETEAM);
     }

--- a/src/test/java/com/herewego/herewegoapi/service/TeamServiceTest.java
+++ b/src/test/java/com/herewego/herewegoapi/service/TeamServiceTest.java
@@ -28,7 +28,7 @@ class TeamServiceTest {
     @BeforeEach
     public void setup() {
         userDetailsRepository.save(UserDetails.builder()
-                .userId(Consts.EMAIL)
+                .userId(Consts.USERID)
                 .favorites(Consts.FAVORITETEAM2)
                 .build());
 
@@ -54,7 +54,7 @@ class TeamServiceTest {
 
     @Test
     void updateFavoriteTeamTest_success() throws ForwardException {
-        teamService.updateFavoriteTeam(Consts.EMAIL, Consts.TEAMNAME2, Consts.LEAGUENAME);
+        teamService.updateFavoriteTeam(Consts.USERID, Consts.TEAMNAME2, Consts.LEAGUENAME);
 
         UserDetails userDetails = userDetailsRepository.findByUserId(Consts.USERID);
         Assertions.assertNotNull(userDetails);

--- a/src/test/java/com/herewego/herewegoapi/service/UserServiceTest.java
+++ b/src/test/java/com/herewego/herewegoapi/service/UserServiceTest.java
@@ -66,7 +66,7 @@ class UserServiceTest {
 
     @Test
     public void getFavoriteTeamIdTest() {
-        List<Integer> favoriteTeamIdList = userService.getFavoritesTeamId(Consts.EMAIL);
+        List<Integer> favoriteTeamIdList = userService.getFavoritesTeamId(Consts.USERID);
 
         Assertions.assertNotNull(favoriteTeamIdList);
         Assertions.assertEquals(2,favoriteTeamIdList.size());
@@ -74,7 +74,7 @@ class UserServiceTest {
 
     @Test
     public void createFavoriteListTest() {
-        List<FavoriteTeamVO> favoriteTeamVOList = userService.createFavoriteList(Consts.EMAIL);
+        List<FavoriteTeamVO> favoriteTeamVOList = userService.createFavoriteList(Consts.USERID);
 
         Assertions.assertNotNull(favoriteTeamVOList);
         Assertions.assertEquals(2,favoriteTeamVOList.size());

--- a/src/test/java/com/herewego/herewegoapi/service/UserServiceTest.java
+++ b/src/test/java/com/herewego/herewegoapi/service/UserServiceTest.java
@@ -33,9 +33,7 @@ class UserServiceTest {
     @BeforeEach
     public void setup() {
         userDetailsRepository.save(UserDetails.builder()
-                .email(Consts.EMAIL)
-                .authProvider(Consts.AUTHPROVIDER)
-                .role(Consts.ROLE)
+                .userId(Consts.USERID)
                 .favorites(Consts.FAVORITETEAM)
                 .build());
 
@@ -54,7 +52,7 @@ class UserServiceTest {
 
     @AfterEach
     public void teardown() {
-        userDetailsRepository.deleteByEmailAndAuthProvider(Consts.EMAIL, Consts.AUTHPROVIDER);
+        userDetailsRepository.deleteByUserId(Consts.USERID);
         teamRepository.deleteByTeamId(Consts.TEAMID1);
         teamRepository.deleteByTeamId(Consts.TEAMID2);
     }


### PR DESCRIPTION
## **[기존 로직 실패 이유]**

redirect url로 로그인한 user의 정보를 내려주는것으로 구현했고, web에서 확인해봤을때, 해당정보가 잘 나오는것까지 확인 후 배포를 진행했었다. 하지만 ios에서는 로그인화면이 chrome으로 나온 이후에, control이 넘어가 이후 과정을 진행할 수 없었다. 

redirect url의 response에 token을 담아주는것으로 구현을 진행했지만, 해당 request는 client에서 온것이 아니라 security 내부 로직상의 request였기 대문에 response로 반환한다고 해서 client로 전달 되지 않았다

##**[해결 방안]**
![image](https://user-images.githubusercontent.com/53139890/212822674-15a838c6-d1a1-4c14-8464-4d72a2c7dad6.png)


client쪽에서 oauth2 로그인을 진행하고, backend에서는 넘어온 access token을 통해 사용자 정보를 서버에서 확인후 일치하는 경우에만 해당 정보를 가지고 JWT를 반환하는 형식으로 진행하도록 했다.