### PR TITLE
[HWG-18] feat: team update 로직 수정

### DIFF
--- a/src/test/java/com/herewego/herewegoapi/service/TeamServiceTest.java
+++ b/src/test/java/com/herewego/herewegoapi/service/TeamServiceTest.java
@@ -64,4 +64,13 @@ class TeamServiceTest {
         Assertions.assertNotNull(userDetails);
         Assertions.assertEquals(userDetails.getFavorites(), Consts.FAVORITETEAM);
     }
+
+    @Test
+    void updateFavoriteTeamTest_duplicatedTeam() throws ForwardException {
+        teamService.updateFavoriteTeam(Consts.USERID, Consts.TEAMID1);
+
+        UserDetails userDetails = userDetailsRepository.findByUserId(Consts.USERID);
+        Assertions.assertNotNull(userDetails);
+        Assertions.assertEquals(userDetails.getFavorites(), Consts.FAVORITETEAM2);
+    }
 }


### PR DESCRIPTION
User 의 favorite 팀 추가 시에, 기존 teamid와 중복되는 teamid가 있는 경우 추가하지 않도록 로직 수정