### PR TITLE
[HWG-21] feat: get Team Detail info API 구현

### DIFF
--- a/src/main/java/com/herewego/herewegoapi/controller/TeamController.java
+++ b/src/main/java/com/herewego/herewegoapi/controller/TeamController.java
@@ -32,4 +32,12 @@ public class TeamController {
             @RequestHeader(value = "UserId") String userId) throws ForwardException {
         return teamService.getTeamList();
     }
+
+    @GetMapping(value = "/teams/{teamId}")
+    public Object getTeamInfo (
+            @RequestHeader(value = "Authorization") String acocuntToken,
+            @RequestHeader(value = "UserId") String userId,
+            @PathVariable(value = "teamId") Integer teamId) throws ForwardException {
+        return teamService.getTeamDetails(userId, teamId);
+    }
 }

--- a/src/main/java/com/herewego/herewegoapi/repository/TeamRepository.java
+++ b/src/main/java/com/herewego/herewegoapi/repository/TeamRepository.java
@@ -3,6 +3,7 @@ package com.herewego.herewegoapi.repository;
 import com.herewego.herewegoapi.model.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
@@ -37,5 +38,12 @@ public interface TeamRepository extends JpaRepository <Team, Long> {
         "ON T.id = subTeam.id " +
         "WHERE subTeam.rnk = 1", nativeQuery = true)
     List<Team> findLatestTeamInfoList();
+
+@Query(value = "SELECT * FROM Team " +
+        "WHERE team_id=:teamId " +
+        "ORDER BY season " +
+        "DESC LIMIT 1", nativeQuery = true)
+    Team findLatestTeamInfo(@Param("teamId") Integer teamId);
+
 
 }

--- a/src/test/java/com/herewego/herewegoapi/common/Consts.java
+++ b/src/test/java/com/herewego/herewegoapi/common/Consts.java
@@ -14,6 +14,7 @@ public class Consts {
     public static final Integer TEAMID2 = 60;
     public static final Integer LEAGUEID = 39;
     public static final Integer SEASON = 2020;
+    public static final Integer SEASON2 = 2021;
     public static final String TEAMNAME1 = "LIV";
     public static final String TEAMNAME2  = "LEEDS";
     public static final String LOGOURL  = "test@test.com";

--- a/src/test/java/com/herewego/herewegoapi/repository/TeamRepositoryTest.java
+++ b/src/test/java/com/herewego/herewegoapi/repository/TeamRepositoryTest.java
@@ -3,6 +3,7 @@ package com.herewego.herewegoapi.repository;
 import com.herewego.herewegoapi.common.Consts;
 import com.herewego.herewegoapi.model.entity.Team;
 import com.herewego.herewegoapi.model.entity.UserDetails;
+import org.apache.tomcat.util.bcel.Const;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +31,14 @@ class TeamRepositoryTest {
                 .build());
 
         teamRepository.save(Team.builder()
+                .teamId(Consts.TEAMID1)
+                .leagueId(Consts.LEAGUEID)
+                .season(Consts.SEASON2)
+                .teamName(Consts.TEAMNAME1)
+                .logo(Consts.LOGOURL)
+                .build());
+
+        teamRepository.save(Team.builder()
                 .teamId(Consts.TEAMID2)
                 .leagueId(Consts.LEAGUEID)
                 .season(Consts.SEASON)
@@ -48,5 +57,11 @@ class TeamRepositoryTest {
     void findLatestTeamInfoList() {
         List<Team> teamList = teamRepository.findLatestTeamInfoList();
         Assertions.assertEquals(2, teamList.size());
+    }
+
+    @Test
+    void findLatestTeamInfo() {
+        Team team = teamRepository.findLatestTeamInfo(Consts.TEAMID1);
+        Assertions.assertEquals(2021, team.getSeason());
     }
 }


### PR DESCRIPTION
## Get Team Detail Info API 
1. 검색창에서 혹은 특정 팀 선택 시 , 호출되는 API
2. 사용자의 각자 설정에 따라 게임단위가 다르며, 해당 게임단위에 따라 그래프가 노출된다.